### PR TITLE
FCMA-752 Fix refresh tokens

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@applyinnovations/ohip-sdk",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "description": "",
   "main": "dist/index.js",
   "scripts": {

--- a/src/index.ts
+++ b/src/index.ts
@@ -151,7 +151,7 @@ export class Api {
 
     // Retry get request
     console.warn(
-      'OHIP responded with error code ${status}, renewing access token and resending request.',
+      `OHIP responded with error code ${error.response.status}, renewing access token and resending request.`,
     );
     this.retryLimit += 1;
     await this.requestNewAuthToken();

--- a/src/index.ts
+++ b/src/index.ts
@@ -101,7 +101,6 @@ export class Api {
       );
       this.setTokenHeaders(data);
     } catch (error) {
-      this.clearTokens();
       await this.requestNewAuthToken();
     }
   }

--- a/src/index.ts
+++ b/src/index.ts
@@ -144,7 +144,7 @@ export class Api {
   private handleClientRequestError = async (error: unknown) => {
     if (
       !isAxiosError(error) ||
-      [401, 403].includes(error.response.status) ||
+      ![401, 403].includes(error.response.status) ||
       this.retryLimit >= REQUEST_RETRY_LIMIT
     )
       return Promise.reject(error);

--- a/templates/swagger-typescript-api/http-client.ejs
+++ b/templates/swagger-typescript-api/http-client.ejs
@@ -38,7 +38,6 @@ export enum ContentType {
 
 export class HttpClient<SecurityDataType = unknown> {
     public instance: AxiosInstance;
-    public prerequest: Promise<any> = Promise.resolve();
     private securityData: SecurityDataType | null = null;
     private securityWorker?: ApiConfig<SecurityDataType>["securityWorker"];
     private secure?: boolean;
@@ -108,9 +107,6 @@ export class HttpClient<SecurityDataType = unknown> {
 <% } else { %>
     }: FullRequestParams): Promise<AxiosResponse<T>> => {
 <% } %>
-        // Wait for the prerequest to resolve before proceeding with the actual request. Useful for waiting for fetching auth tokens
-        await this.prerequest;
-
         const secureParams = ((typeof secure === 'boolean' ? secure : this.secure) && this.securityWorker && (await this.securityWorker(this.securityData))) || {};
         const requestParams = this.mergeRequestParams(params, secureParams);
         const responseFormat = (format || this.format) || undefined;


### PR DESCRIPTION
- [x] The hosted hms service should be able to refresh a old access token
- [x] Remove old setInterval code that refreshes the access token, instead, before each request, the access token expiry is checked and the access token is refreshed if it will expire in the next 300 seconds or has already expired.
- [ ] All services that use the ohip sdk have been updated to the latest version
- [x] If a request fails due to an invalid / expired access token (402 Unauthorised) then the access token is refreshed and the request is sent again (only one retry - to avoid infinite loop)

Note:
- Retry was only implemented on get requests, but also on 401 error codes
- I didn't used `openapi-typescript-codegen` since this issue always occurs. I couldn't figure out why that model isn't generated even if it is present on the swagger spec itself.
![Screen Shot 2023-01-24 at 11 43 01 AM](https://user-images.githubusercontent.com/113871905/214215127-03dd47c4-9b02-494e-b3ca-01ce7c199086.png)

