### PR TITLE
fix: publish release tarball by local path

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,18 +4,24 @@ on:
   release:
     types:
       - published
+  workflow_dispatch:
+    inputs:
+      release_tag:
+        description: Existing source release tag to retry
+        required: true
+        default: v2.0.0
 
 permissions:
   contents: write
   id-token: write
 
 concurrency:
-  group: release-${{ github.event.release.tag_name }}
+  group: release-${{ github.event.release.tag_name || inputs.release_tag }}
   cancel-in-progress: false
 
 jobs:
   publish:
-    if: startsWith(github.event.release.tag_name, 'v')
+    if: startsWith(github.event.release.tag_name || inputs.release_tag, 'v')
     runs-on: ubuntu-latest
     timeout-minutes: 60
     environment: npm
@@ -24,12 +30,12 @@ jobs:
       - name: Check out source release
         uses: actions/checkout@v6
         with:
-          ref: ${{ github.event.release.tag_name }}
+          ref: ${{ github.event.release.tag_name || inputs.release_tag }}
           fetch-depth: 0
 
       - name: Verify release version
         env:
-          RELEASE_TAG: ${{ github.event.release.tag_name }}
+          RELEASE_TAG: ${{ github.event.release.tag_name || inputs.release_tag }}
         run: node scripts/assert-release-version.mjs
 
       - name: Read pinned Oracle commit
@@ -78,7 +84,7 @@ jobs:
 
       - name: Commit generated Go modules
         env:
-          RELEASE_TAG: ${{ github.event.release.tag_name }}
+          RELEASE_TAG: ${{ github.event.release.tag_name || inputs.release_tag }}
         run: |
           version="${RELEASE_TAG#v}"
           branch="generated/$RELEASE_TAG"
@@ -130,19 +136,20 @@ jobs:
           if npm view "$package@$version" version >/dev/null 2>&1; then
             echo "$package@$version is already published."
           else
-            npm publish release-artifacts/*.tgz --access public --provenance
+            npm publish ./release-artifacts/*.tgz --access public --provenance
           fi
 
       - name: Attach npm package to GitHub release
         uses: softprops/action-gh-release@v2
         with:
+          tag_name: ${{ github.event.release.tag_name || inputs.release_tag }}
           files: release-artifacts/*.tgz
 
       - name: Upload generator log
         if: always()
         uses: actions/upload-artifact@v4
         with:
-          name: openapi-generator-log-${{ github.event.release.tag_name }}
+          name: openapi-generator-log-${{ github.event.release.tag_name || inputs.release_tag }}
           path: build.log
           if-no-files-found: ignore
           retention-days: 30


### PR DESCRIPTION
npm 11 interpreted the unprefixed tarball path as GitHub shorthand. Prefix the local artifact with ./ and add a workflow-dispatch retry path that rebuilds from the immutable release tag. Existing generated Go refs are verified on retry.