### PR TITLE
fix: publish npm package with trusted OIDC

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -131,8 +131,6 @@ jobs:
           fi
 
       - name: Publish TypeScript package with provenance
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
         run: |
           package=$(node -p "require('./package.json').name")
           version=$(node -p "require('./package.json').version")


### PR DESCRIPTION
## Summary

- remove the legacy `NPM_TOKEN` environment variable from npm publishing
- require npm Trusted Publishing/OIDC for future releases
- retain provenance and public access settings

## Validation

- `git diff --check`
- `go run github.com/rhysd/actionlint/cmd/actionlint@v1.7.7 .github/workflows/release.yml`