### PR TITLE
chore: dispatch publication after release

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -7,6 +7,7 @@ on:
   workflow_dispatch:
 
 permissions:
+  actions: write
   contents: write
   pull-requests: write
 
@@ -14,7 +15,15 @@ jobs:
   release-please:
     runs-on: ubuntu-latest
     steps:
-      - uses: googleapis/release-please-action@v4
+      - id: release
+        uses: googleapis/release-please-action@v4
         with:
           config-file: release-please-config.json
           manifest-file: .release-please-manifest.json
+
+      - name: Dispatch package publication
+        if: steps.release.outputs.release_created == 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          RELEASE_TAG: ${{ steps.release.outputs.tag_name }}
+        run: gh workflow run release.yml --ref main -f "release_tag=$RELEASE_TAG"


### PR DESCRIPTION
## Summary

- capture Release Please outputs
- explicitly dispatch `release.yml` after a GitHub release is created
- grant only the additional `actions: write` permission required for that dispatch
- keep npm Trusted Publisher identity bound to `release.yml`

GitHub suppresses ordinary recursive workflow events created with `GITHUB_TOKEN`, while `workflow_dispatch` is an allowed exception.

## Validation

- `git diff --check`
- `go run github.com/rhysd/actionlint/cmd/actionlint@v1.7.7 .github/workflows/release-please.yml .github/workflows/release.yml`