### PR TITLE
chore(ci): scope release dispatch to repository

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -26,4 +26,6 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
           RELEASE_TAG: ${{ steps.release.outputs.tag_name }}
-        run: gh workflow run release.yml --ref main -f "release_tag=$RELEASE_TAG"
+        run: >-
+          gh workflow run release.yml --repo "$GITHUB_REPOSITORY" --ref main
+          -f "release_tag=$RELEASE_TAG"


### PR DESCRIPTION
## Summary

- pass the repository explicitly when Release Please dispatches `release.yml`
- avoid GitHub CLI attempting to discover a `.git` checkout in the checkout-free release job

## Context

Release Please created v3.0.0 successfully, but the follow-up dispatch failed before publication because `gh workflow run` had no repository context. The v3.0.0 publish was safely re-dispatched with the explicit repository.

## Validation

- the equivalent explicit `gh workflow run --repo applyinnovations/ohip-sdk ...` command successfully started publish run 29686682955
- `git diff --check